### PR TITLE
Add initial implementation of logger

### DIFF
--- a/common/include/common.h
+++ b/common/include/common.h
@@ -1,5 +1,7 @@
 #include <stdint.h>
 
+#include "logger.h"
+
 inline uint32_t add_two_uints(uint32_t a, uint32_t b) { return a + b; }
 
 template <uint32_t Size>
@@ -35,10 +37,12 @@ struct SizedText {
     const char* c_str() const { return text_.data(); }
 
     void print() const {
+        std::ostringstream ss;
         for (uint32_t i = 0; i < actualSize; i++) {
-            std::cout << text_.at(i);
+            ss << text_.at(i);
         }
-        std::cout << std::endl;
+        ss << std::endl;
+        LOG_I() << ss.str();
     }
 
     uint32_t getSize() { return actualSize; }

--- a/common/src/CMakeLists.txt
+++ b/common/src/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(converters)
+add_subdirectory(logger)

--- a/common/src/logger/CMakeLists.txt
+++ b/common/src/logger/CMakeLists.txt
@@ -1,12 +1,14 @@
-project(common_include)
+project(logger)
+
+file(GLOB SourceFiles *.h *.cpp)
 
 if(CMAKE_CROSSCOMPILING)
     add_compile_definitions(CROSS_COMPILING)
 endif()
 
-add_library(${PROJECT_NAME} INTERFACE)
+add_library(${PROJECT_NAME} INTERFACE ${SourceFiles})
 
-target_link_libraries(${PROJECT_NAME} INTERFACE logger)
+#target_link_libraries(${PROJECT_NAME} INTERFACE common_include)
 
 # Export include files
 target_include_directories(${PROJECT_NAME} INTERFACE

--- a/common/src/logger/logger.cpp
+++ b/common/src/logger/logger.cpp
@@ -1,0 +1,8 @@
+#include "logger.h"
+
+#include <iostream>
+
+namespace common {
+
+
+}  // namespace common

--- a/common/src/logger/logger.h
+++ b/common/src/logger/logger.h
@@ -1,0 +1,101 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+#include <cstdint>
+#include <iostream>
+#include <mutex>
+
+namespace common {
+enum class Severity : uint8_t {
+    VERBOSE = 0,
+    DEBUG = 1,
+    INFO = 2,
+    WARNING = 3,
+    BYPASS = 4
+};
+
+/**
+ * @class Logger
+ * @brief singleton class
+ *
+ */
+class Logger {
+    Severity defaultSeverity_{Severity::WARNING};
+    Severity currentSeverity_{Severity::BYPASS};
+    std::mutex m_{};
+    bool isFirst{true};
+
+    Logger() {};
+
+   public:
+    Logger(const Logger&) = delete;
+    Logger(const Logger&&) = delete;
+    Logger& operator=(const Logger&) = delete;
+    Logger& operator=(const Logger&&) = delete;
+
+    static Logger& getLogger() {
+        static Logger logger;
+        return logger;
+    }
+
+    void setSeverity(std::string_view severity) {
+        if (severity.find("I") != std::string::npos) {
+            defaultSeverity_ = Severity::INFO;
+        } else if (severity.find("W") != std::string::npos) {
+            defaultSeverity_ = Severity::WARNING;
+        } else if (severity.find("V") != std::string::npos) {
+            defaultSeverity_ = Severity::VERBOSE;
+        } else if (severity.find("D") != std::string::npos) {
+            defaultSeverity_ = Severity::DEBUG;
+        } else {
+            defaultSeverity_ = Severity::INFO;
+        }
+    }
+
+    Logger& log(Severity&& sev) {
+        currentSeverity_ = sev;
+
+        if (currentSeverity_ >= defaultSeverity_) {
+            if (!isFirst) {
+                std::cout << "\n";
+            } else {
+                isFirst = false;
+            }
+
+            if (sev == Severity::VERBOSE) {
+                std::cout << "[VRB] ";
+            } else if (sev == Severity::DEBUG) {
+                std::cout << "[DBG] ";
+
+            } else if (sev == Severity::INFO) {
+                std::cout << "[INF] ";
+            } else if (sev == Severity::WARNING) {
+                std::cout << "[WRN] ";
+            } else {
+                // bypass
+            }
+        }
+        return *this;
+    }
+
+    template <class T>
+    Logger& operator<<(const T& message) {
+        std::lock_guard<std::mutex> guard{m_};
+        std::ostringstream oss;
+        oss << message;
+
+        if (currentSeverity_ >= defaultSeverity_) {
+            std::cout << oss.str();
+        }
+        return *this;
+    }
+};
+
+/// TODO: add module name
+#define LOG_B() common::Logger::getLogger().log(common::Severity::BYPASS)
+#define LOG_V() common::Logger::getLogger().log(common::Severity::VERBOSE)
+#define LOG_D() common::Logger::getLogger().log(common::Severity::DEBUG)
+#define LOG_I() common::Logger::getLogger().log(common::Severity::INFO)
+#define LOG_W() common::Logger::getLogger().log(common::Severity::WARNING)
+};  // namespace common
+
+#endif

--- a/common/test/test_common_include/CMakeLists.txt
+++ b/common/test/test_common_include/CMakeLists.txt
@@ -10,6 +10,7 @@ target_link_libraries(${PROJECT_NAME}
     libgmock
     common_include
     converters
+    logger
 )
 
 add_test(

--- a/common/test/test_common_include/test_common_include.cpp
+++ b/common/test/test_common_include/test_common_include.cpp
@@ -2,6 +2,7 @@
 
 #include "common.h"
 #include "eval.h"
+#include "logger.h"
 
 TEST(TestOne, test) { 
     ASSERT_TRUE(true); 
@@ -16,3 +17,12 @@ TEST(TestEval, init) {
     op.compute();
 }
 
+TEST(TestLogger, init) {
+    common::Logger& logger = common::Logger::getLogger();
+    logger.log(common::Severity::VERBOSE)
+        << "More stuff here" << " and here: " << 5;
+
+    logger.log(common::Severity::VERBOSE)
+        << "Another one " << " and here: " << 5;
+    //
+}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -4,5 +4,5 @@ file(GLOB_RECURSE SourceFiles LIST_DIRECTORIES false *.h *.cpp)
 
 add_executable(${PROJECT_NAME} ${SourceFiles})
 
-target_link_libraries(${PROJECT_NAME} common_include converters argparse)
+target_link_libraries(${PROJECT_NAME} common_include converters argparse logger)
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -8,9 +8,13 @@
 #include "common.h"
 #include "converters.h"
 #include "eval.h"
+#include "logger.h"
 
 int main(int argc, char** argv) {
     argparse::ArgumentParser program("hxr");
+    program.add_argument("--log-level")
+        .help("Log level [V]erbose, D[ebug], I[nfo], W[arning]")
+        .default_value("I");
     argparse::ArgumentParser query_command("query");
     argparse::ArgumentParser evaluate_command("evaluate");
 
@@ -39,6 +43,11 @@ int main(int argc, char** argv) {
         std::cerr << program;
         return 1;
     }
+
+    // get and set log-level
+    common::Logger::getLogger().setSeverity(
+        program.get<std::string>("--log-level"));
+
 
     if (program.is_subcommand_used("query")) {
         auto showBin = query_command.get<bool>("b");
@@ -76,12 +85,14 @@ int main(int argc, char** argv) {
 
         if (isSigned) {
             if (is64Bit) {
+                LOG_V() << "Is signed 64";
                 int64_t number =
                     static_cast<int64_t>(query_command.get<int64_t>("d"));
                 converters::Hexer<int64_t> hxr{number};
                 hxr.setShowBinary(showBin);
                 hxr.run();
             } else {
+                LOG_V() << "Is signed 32";
                 int32_t number =
                     static_cast<int32_t>(query_command.get<int64_t>("d"));
                 converters::Hexer<int32_t> hxr{number};
@@ -90,11 +101,13 @@ int main(int argc, char** argv) {
             }
         } else {
             if (is64Bit) {
+                LOG_V() << "Is unsigned 64";
                 auto number = query_command.get<uint64_t>("u");
                 converters::Hexer<uint64_t> hxr{number};
                 hxr.setShowBinary(showBin);
                 hxr.run();
             } else {
+                LOG_V() << "Is unsigned 32";
                 uint32_t number =
                     static_cast<uint32_t>(query_command.get<uint64_t>("u"));
                 converters::Hexer<uint32_t> hxr{number};


### PR DESCRIPTION
Implemented logger as a singleton in common/src/logger.

I think some things can be improved. Overall it does the job of abstracting standard output and implements levels of logging.

I have mixed logging and "general" prints together, which I am not sure this is standard practice. I think there can be improvements. Of note is ofc the missing module name for the prints. There might also be a slight inefficiency when calling log() >> "", as the check for severity level is done twice.

I will create a ticket to follow-up on this but for this this'll do.

	modified:   common/include/CMakeLists.txt
	modified:   common/include/common.h
	modified:   common/src/CMakeLists.txt
	modified:   common/src/converters/converters.h
	new file:   common/src/logger/CMakeLists.txt
	new file:   common/src/logger/logger.cpp
	new file:   common/src/logger/logger.h
	modified:   common/test/test_common_include/CMakeLists.txt
	modified:   common/test/test_common_include/test_common_include.cpp
	modified:   main/CMakeLists.txt
	modified:   main/main.cpp